### PR TITLE
Misc. security fixes

### DIFF
--- a/shgysk8zer0/cookies.php
+++ b/shgysk8zer0/cookies.php
@@ -64,7 +64,7 @@ final class Cookies implements \Iterator, \JSONSerializable
 		URL  $url      = null,
 		int  $expires  = 0,
 		bool $secure   = null,
-		bool $httponly = false
+		bool $httponly = true
 	)
 	{
 		if (is_null($url)) {
@@ -79,7 +79,7 @@ final class Cookies implements \Iterator, \JSONSerializable
 		$this->setPath($url->pathname);
 		$this->setSecure($secure);
 		$this->setHttpOnly($httponly);
-		$this->setDomain($url->origin);
+		$this->setDomain($url->hostname);
 
 		if (is_null(static::$_instance)) {
 			static::$_instance = $this;
@@ -262,11 +262,7 @@ final class Cookies implements \Iterator, \JSONSerializable
 
 	public function setDomain(string $domain): void
 	{
-		if (filter_var($domain, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED)) {
-			$this->_domain = $domain;
-		} else {
-			throw new \InvalidArgumentException(sprintf('"%s" is not a valid domain', $domain));
-		}
+		$this->_domain = $domain;
 	}
 
 	public function setPath(string $path): void

--- a/shgysk8zer0/session.php
+++ b/shgysk8zer0/session.php
@@ -42,7 +42,7 @@ final class Session implements \Iterator, \JSONSerializable
 				$secure = array_key_exists('HTTPS', $_SERVER) and ! empty($_server['HTTPS']);
 			}
 			if (is_null($domain)) {
-				$domain = URL::getRequestUrl()->origin;
+				$domain = URL::getRequestUrl()->hostname;
 			}
 			//Avoid trying to figure out cookie paramaters for CLI
 			if (PHP_SAPI !== 'cli') {
@@ -57,6 +57,7 @@ final class Session implements \Iterator, \JSONSerializable
 				}
 			}
 			session_start();
+			$cookie[session_name()] = session_id();
 		}
 
 		if (is_null(static::$_instance)) {
@@ -233,6 +234,11 @@ final class Session implements \Iterator, \JSONSerializable
 		return session_get_cookie_params();
 	}
 
+	final public function getId(): string
+	{
+		return session_id();
+	}
+
 	final public static function status(): int
 	{
 		return session_status();
@@ -247,6 +253,7 @@ final class Session implements \Iterator, \JSONSerializable
 	{
 		return static::status() === PHP_SESSION_DISABLED;
 	}
+
 
 	final public static function getInstance(): self
 	{

--- a/shgysk8zer0/uploadfile.php
+++ b/shgysk8zer0/uploadfile.php
@@ -72,15 +72,13 @@ class UploadFile implements JSONSerializable
 	final public function jsonSerialize(): array
 	{
 		return [
-			'uploadPath' => $this->_uploadPath,
-			'path'       => $this->_path,
-			'hash'       => $this->getHash(),
 			'name'       => $this->_name,
-			'size'       => $this->_size,
 			'type'       => $this->_type,
 			'extension'  => $this->extension,
-			'moved'      => $this->isMoved(),
-			'url'        => $this->getUrl(),
+			'size'       => $this->_size,
+			'url'        => $this->isMoved() ? $this->getUrl() : null,
+			'hash'       => $this->getHash(),
+			'saved'      => $this->isMoved(),
 		];
 	}
 

--- a/test/index.php
+++ b/test/index.php
@@ -1,30 +1,34 @@
 <?php
 namespace Test;
-use \shgysk8zer0\{API, URL, Headers, HTTPException};
+use \shgysk8zer0\{API, Headers, HTTPException};
 use \shgysk8zer0\Abstracts\{HTTPStatusCodes as HTTP};
-use const \Consts\{HOST, BASE_URI};
-use \Throwable;
+
 require_once  dirname(__DIR__) . DIRECTORY_SEPARATOR . 'autoloader.php';
 
 try {
 	$api = new API('*');
+
 	$api->on('GET', function(API $request): void
 	{
-		Headers::set('Content-Type', 'application/json');
-		echo json_encode([
-			'HOST' => HOST,
-			'BASE_URI' => BASE_URI,
-			'url' => URL::getRequestUrl(),
-			'request' => $request,
-		]);
+		Headers::contentType('application/json');
+		echo json_encode($request);
 	});
+
+	$api->on('POST', function(API $request): void
+	{
+		Headers::contentType('application/json');
+		echo json_encode($request);
+	});
+
+	$api->on('DELETE', function(API $request): void
+	{
+		Headers::contentType('application/json');
+		echo json_encode($request);
+	});
+
 	$api();
 } catch (HTTPException $e) {
 	Headers::status($e->getCode());
 	Headers::set('Content-Type', 'application/json');
 	echo json_encode($e);
-} catch(\Throwable $e) {
-	Headers::status(HTTP::INTERNAL_SERVER_ERROR);
-	Headers::set('Content-Type', 'text/plain');
-	exit('Internal Server Error');
 }


### PR DESCRIPTION
- Fix domain for `Session` & `Cookies`
- Do not incude session in `API::jsonSerialize`
- Do not include path (tmpPath) in `UploadFile::jsonSerialize`
- Do not include URL of unmoved/unsaved files in `UploadFile::jsonSerialize`
- Default to httponly in `Cookies`
- Test script now echos request for GET & POST