### PR TITLE
Add missing CORS headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: Report a bug
 labels: bug
-assignees: ''
+assignees: 'shgysk8zer0'
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: Request a feature
 labels: enhancement
-assignees: ''
+assignees: 'shgysk8zer0'
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.0.1] 2020-06-23
 
 ### Fixed
-- Add missing CORS headers (#54)
+- Add missing CORS headers (#53)
 
 ## [v1.0.0] 2020-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0] 2020-06-23
 <!-- markdownlint-disable -->
+## [v1.0.1] 2020-06-23
+
+### Fixed
+- Add missing CORS headers (#54)
+
+## [v1.0.0] 2020-06-23
+
 ### Added
 - Update PHPAPI
 - Add several others

--- a/river/index.php
+++ b/river/index.php
@@ -6,7 +6,7 @@ use \shgysk8zer0\HTTP\{Request, Response, Body, Headers, URL, ContentSecurityPol
 
 use \shgysk8zer0\HTTP\Abstracts\{HTTPStatusCodes as HTTP};
 
-use \shgysk8zer0\PHPAPI\{SAPILogger, ConsoleLogger, FileCache, LoggerSubject, Template};
+use \shgysk8zer0\PHPAPI\{SAPILogger, ConsoleLogger, FileCache, LoggerSubject, UUID};
 
 use \Throwable;
 
@@ -121,7 +121,11 @@ try {
 
 		$resp = new Response(new Body(json_encode($entries)), [
 			'headers' => new Headers([
-				'Content-Type' => 'application/json',
+				'Content-Type'                 => 'application/json',
+				'Access-Control-Allow-Origin'  => '*',
+				'Access-Control-Allow-Methods' => 'OPTIONS, GET',
+				'Access-Control-Allow-Headers' => 'Accept, Content-Type, Upgrade-Insecure-Requests',
+				'X-REQUEST-UUID'               => new UUID(),
 			]),
 			'status'  => HTTP::OK,
 		]);


### PR DESCRIPTION
Resolves #53 

```php
$resp = new Response(new Body(json_encode($entries)), [
	'headers' => new Headers([
		'Content-Type' => 'application/json',
		'Content-Type'                 => 'application/json',
		'Access-Control-Allow-Origin'  => '*',
		'Access-Control-Allow-Methods' => 'OPTIONS, GET',
		'Access-Control-Allow-Headers' => 'Accept, Content-Type, Upgrade-Insecure-Requests',
		'X-REQUEST-UUID'               => new UUID(),
	]),
	'status'  => HTTP::OK,
]);
```